### PR TITLE
Derive guard name from user_type

### DIFF
--- a/src/PasswordlessLoginService.php
+++ b/src/PasswordlessLoginService.php
@@ -48,7 +48,10 @@ class PasswordlessLoginService
     public function getUser()
     {
         if (request()->has('user_type')) {
-            return Auth::guard(config('laravel-passwordless-login.user_guard'))
+
+            $guard = (new (UserClass::fromSlug(request('user_type'))))->guard_name ?? config('laravel-passwordless-login.user_guard');
+            
+            return Auth::guard($guard)
                 ->getProvider()
                 ->retrieveById(request('uid'));
         }


### PR DESCRIPTION
Derive the guard name from the `user_type` if the model has the `guard_name` attribute. Fall back to the configured guard if not.